### PR TITLE
Add CentOS 7 + Devtoolset 7 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### [`prebuild/linux-arm64`](https://hub.docker.com/r/prebuild/linux-arm64)
 ### [`prebuild/linux-armv7`](https://hub.docker.com/r/prebuild/linux-armv7)
 ### [`prebuild/alpine`](https://hub.docker.com/r/prebuild/alpine)
+### [`prebuild/centos7-devtoolset7`](https://hub.docker.com/r/prebuild/centos7-devtoolset7)
 
 ## License
 

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos/devtoolset-7-toolchain-centos7
+
+USER 0
+
+RUN groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
+  groupadd -g 2000 travis && useradd -g 2000 -u 2000 -m travis
+
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
+  yum install -y nodejs
+
+USER node
+
+WORKDIR /opt/app-root

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -10,4 +10,4 @@ RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
 
 USER node
 
-WORKDIR /opt/app-root
+WORKDIR /app

--- a/centos7-devtoolset7/Makefile
+++ b/centos7-devtoolset7/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t prebuild/centos7-devtoolset7 .
+
+push:
+	docker push prebuild/centos7-devtoolset7


### PR DESCRIPTION
Ref: https://github.com/Level/leveldown/pull/672

```
$ docker run --rm prebuild/centos7-devtoolset7:latest node -v
v12.10.0
$ docker run --rm prebuild/centos7-devtoolset7:latest gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/opt/rh/devtoolset-7/root/usr/libexec/gcc/x86_64-redhat-linux/7/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,lto --prefix=/opt/rh/devtoolset-7/root/usr --mandir=/opt/rh/devtoolset-7/root/usr/share/man --infodir=/opt/rh/devtoolset-7/root/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-plugin --with-linker-hash-style=gnu --enable-initfini-array --with-default-libstdcxx-abi=gcc4-compatible --with-isl=/builddir/build/BUILD/gcc-7.3.1-20180303/obj-x86_64-redhat-linux/isl-install --enable-libmpx --enable-gnu-indirect-function --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 7.3.1 20180303 (Red Hat 7.3.1-5) (GCC)
```

The neat thing about this is that you get to compile with gcc 7 but glibc 2.17, so binaries are compatible for Ubuntu 14.04 and Debian 8.