### PR TITLE
Add Dockerfile for linux-armv6

### DIFF
--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -1,0 +1,30 @@
+FROM dockcross/linux-armv6
+
+RUN groupadd --gid 1000 node && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN groupadd --gid 2000 travis && useradd --uid 2000 --gid travis --shell /bin/bash --create-home travis
+
+RUN apt-get -y update && \
+  apt-get -y --no-install-recommends install \
+    git curl gnupg apt-transport-https \
+    && \
+  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  apt-get -y update && \
+  apt-get -y install nodejs && \
+  rm -rf /var/lib/apt/lists/*
+
+USER node
+
+ENV PREBUILD_STRIP_BIN ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip
+ENV PREBUILD_ARCH arm
+ENV PREBUILD_ARMV 6
+ENV PREBUILD_PLATFORM linux
+
+# TODO: These are for backwards compat. Remove once we have versioning.
+ENV STRIP ${PREBUILD_STRIP_BIN}
+ENV ARCH ${PREBUILD_ARCH}
+ENV ARM_VERSION ${PREBUILD_ARMV}
+ENV TARGET_PLATFORM ${PREBUILD_PLATFORM}
+
+WORKDIR /app

--- a/linux-armv6/Makefile
+++ b/linux-armv6/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t prebuild/linux-armv6 .
+
+push:
+	docker push prebuild/linux-armv6


### PR DESCRIPTION
Problem: Prebuilds aren't supported on the Pi Zero, which runs ARMv6.

Solution: Copy the ARMv7 Dockerfile, replace the relevant strings to
support ARMv6 instead, and add the files to the repository. I've only
tested to ensure that the Dockerfile builds cleanly, but haven't spent
any time on further testing.

See also: https://github.com/Level/leveldown/issues/703