### PR TITLE
Add Android ARMv8 support

### DIFF
--- a/android-armv8/Dockerfile
+++ b/android-armv8/Dockerfile
@@ -1,0 +1,32 @@
+FROM dockcross/android-arm
+
+RUN groupadd --gid 1000 node && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN groupadd --gid 2000 travis && useradd --uid 2000 --gid travis --shell /bin/bash --create-home travis
+
+RUN apt-get -y update && \
+  apt-get -y --no-install-recommends install \
+    git curl gnupg apt-transport-https \
+    && \
+  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  apt-get -y update && \
+  apt-get -y install nodejs && \
+  rm -rf /var/lib/apt/lists/*
+
+USER node
+
+ENV PREBUILD_STRIP_BIN ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip
+ENV PREBUILD_ARCH arm
+ENV PREBUILD_ARMV 8
+ENV PREBUILD_PLATFORM android
+
+# TODO: These are for backwards compat. Remove once we have versioning.
+ENV STRIP ${PREBUILD_STRIP_BIN}
+ENV ARCH ${PREBUILD_ARCH}
+ENV ARM_VERSION ${PREBUILD_ARMV}
+ENV TARGET_PLATFORM ${PREBUILD_PLATFORM}
+
+ENV GYP_DEFINES target_arch=arm android_target_arch=arm host_os=linux OS=android
+
+WORKDIR /app

--- a/android-armv8/Makefile
+++ b/android-armv8/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t prebuild/android-armv8 .
+
+push:
+	docker push prebuild/android-armv8


### PR DESCRIPTION
Problem: When installing Leveldown on the Google Pixel XL I noticed that
it's complaining that it cannot locate symbol "_Unwind_Resume".

Solution: I don't know why this is happening, but I'm wondering whether
a prebuild would solve the problem. This commit adds Android ARMv8
support, which I *think* should work as a prebuild on my device. I'm a
bit out of my element and wouldn't be surprised if this is the wrong
move.

See: https://github.com/Level/leveldown/issues/705