### PR TITLE
Install nodejs package from correct source

### DIFF
--- a/android-arm64/Dockerfile
+++ b/android-arm64/Dockerfile
@@ -8,10 +8,14 @@ RUN apt-get -y update && \
     git curl gnupg apt-transport-https \
     && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_10.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x bullseye main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  npm -v && \
   rm -rf /var/lib/apt/lists/*
 
 USER node

--- a/android-armv7/Dockerfile
+++ b/android-armv7/Dockerfile
@@ -8,10 +8,14 @@ RUN apt-get -y update && \
     git curl gnupg apt-transport-https \
     && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_10.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x bullseye main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  npm -v && \
   rm -rf /var/lib/apt/lists/*
 
 USER node

--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -8,10 +8,14 @@ RUN apt-get -y update && \
     git curl gnupg apt-transport-https \
     && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_10.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x bullseye main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  npm -v && \
   rm -rf /var/lib/apt/lists/*
 
 USER node

--- a/linux-armv6/Dockerfile
+++ b/linux-armv6/Dockerfile
@@ -8,10 +8,14 @@ RUN apt-get -y update && \
     git curl gnupg apt-transport-https \
     && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_10.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x bullseye main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  npm -v && \
   rm -rf /var/lib/apt/lists/*
 
 USER node

--- a/linux-armv7/Dockerfile
+++ b/linux-armv7/Dockerfile
@@ -8,10 +8,14 @@ RUN apt-get -y update && \
     git curl gnupg apt-transport-https \
     && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list && \
-  echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_10.x bullseye main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb-src https://deb.nodesource.com/node_10.x bullseye main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  npm -v && \
   rm -rf /var/lib/apt/lists/*
 
 USER node


### PR DESCRIPTION
In our dockcross-based images, the 'nodejs' package is available in both default debian sources and nodesource. Debian's package does not include npm.

Not sure what changed or when, but it's fixed by increasing the priority of nodesource. This in turn revealed that we were targeting the wrong debian version; should be bullseye instead of buster.

Closes #17 and unblocks https://github.com/Level/leveldown/pull/764.