### PR TITLE
Move from Docker Hub to GitHub Container Registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  # Other base images are unversioned
+  - package-ecosystem: docker
+    directory: /centos7-devtoolset7
+    schedule:
+      interval: monthly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+on:
+  push:
+    branches: [master]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - alpine
+          - android-armv7
+          - android-arm64
+          - centos7-devtoolset7
+          - linux-armv6
+          - linux-armv7
+          - linux-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.image }}
+          tags: |
+            ghcr.io/prebuild/${{ matrix.image }}:latest
+            ghcr.io/prebuild/${{ matrix.image }}:1
+          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master]
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
 jobs:
   build:
     name: Build
@@ -28,11 +28,36 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare tags
+        run: |
+          echo "MAJOR=$(echo ${GITHUB_REF/refs\/tags\/v/} | awk -F '.' '{print $1}')" >> $GITHUB_ENV
+          echo "MINOR=$(echo ${GITHUB_REF/refs\/tags\/v/} | awk -F '.' '{print $1"."$2}')" >> $GITHUB_ENV
+          echo "PATCH=$(echo ${GITHUB_REF/refs\/tags\/v/} | awk -F '.' '{print $1"."$2"."$3}')" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.image }}
           tags: |
             ghcr.io/prebuild/${{ matrix.image }}:latest
-            ghcr.io/prebuild/${{ matrix.image }}:1
+            ghcr.io/prebuild/${{ matrix.image }}:${{ env.MAJOR }}
+            ghcr.io/prebuild/${{ matrix.image }}:${{ env.MINOR }}
+            ghcr.io/prebuild/${{ matrix.image }}:${{ env.PATCH }}
+          labels: |
+            org.opencontainers.image.version=${{ env.PATCH }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=GPL-3.0-only
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/releases/tag/v${{ env.PATCH }}
           push: true
+  release:
+    name: Release
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create GitHub release
+        uses: docker://antonyurchenko/git-release:v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## About
 
-All images include `node`, `npm`, `npx` and a build toolchain suitable for `node-gyp` and `prebuildify`. For example:
+All images include `node`, `npm`, `npx` and a preconfigured build toolchain suitable for `node-gyp` and `prebuildify`. For example:
 
 ```
 > docker run --rm -it ghcr.io/prebuild/alpine node -v
-v12.16.0
+v14.17.4
 ```
 
 Images are tagged with a major, minor and full version as well as `latest`. For example, use the following to pin to major version 1:
@@ -20,6 +20,14 @@ Images are tagged with a major, minor and full version as well as `latest`. For 
 ```dockerfile
 FROM ghcr.io/prebuild/alpine:1
 ```
+
+## Versioning guarantees
+
+Within a major version range, we will not change toolchains, environment variables, working directories, users and more. However, the Node.js version will change without notice. We use Node.js [LTS](https://github.com/nodejs/Release) (at the time of building images) for a light maintenance effort. This is okay because `prebuildify` can target (the headers of) older Node.js versions while itself running on a newer version.
+
+We've yet to align Python versions ([#15](https://github.com/prebuild/docker-images/issues/15)). A next major will use Python 3.
+
+Images that are based on [`dockcross`](https://github.com/dockcross/dockcross) (see below) may inadvertently introduce breaking changes because `dockcross` does not use semantic versions ([dockcross/dockcross#399](https://github.com/dockcross/dockcross/issues/399)) and does not maintain a changelog that would allow us to easily categorize changes and then tag our images accordingly. If this concerns you we recommend pinning to an exact version (`x.x.x`) which we treat as immutable.
 
 ## Images
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,76 @@
 # docker-images
 
-> Docker images for cross compiling prebuilt binaries for node.js
+**Docker images for cross compiling prebuilt binaries for Node.js. Used by [`prebuildify-cross`](https://github.com/prebuild/prebuildify-cross).**
+
+[![Release](https://github.com/prebuild/docker-images/actions/workflows/release.yml/badge.svg)](https://github.com/prebuild/docker-images/actions/workflows/release.yml)
+
+## About
+
+All images include `node`, `npm`, `npx` and a build toolchain suitable for `node-gyp` and `prebuildify`. For example:
+
+```
+> docker run --rm -it ghcr.io/prebuild/alpine node -v
+v12.16.0
+```
+
+Images are tagged with a major version number as well as `latest`. For example, use the following to pin to version 1:
+
+```dockerfile
+FROM ghcr.io/prebuild/alpine:1
+```
 
 ## Images
 
-### [`prebuild/android-arm64`](https://hub.docker.com/r/prebuild/android-arm64)
-### [`prebuild/android-armv7`](https://hub.docker.com/r/prebuild/android-armv7)
-### [`prebuild/linux-arm64`](https://hub.docker.com/r/prebuild/linux-arm64)
-### [`prebuild/linux-armv7`](https://hub.docker.com/r/prebuild/linux-armv7)
-### [`prebuild/alpine`](https://hub.docker.com/r/prebuild/alpine)
-### [`prebuild/centos7-devtoolset7`](https://hub.docker.com/r/prebuild/centos7-devtoolset7)
+### [`centos7-devtoolset7`](https://github.com/orgs/prebuild/packages/container/package/centos7-devtoolset7)
+
+Compile in CentOS 7, as a better alternative to (commonly) Ubuntu 16.04 on Travis or GitHub Actions. Makes prebuilds compatible with Debian 8, Ubuntu 14.04, RHEL 7, CentOS 7 and other Linux flavors with an old glibc.
+
+> The neat thing about this is that you get to compile with gcc 7 but glibc 2.17, so binaries are compatible for \[among others] Ubuntu 14.04 and Debian 8.
+>
+> The RHEL folks put in a ton of work to make the devtoolsets work on their older base systems (libc mainly), which involves shipping a delta library that contains the new stuff that can be statically linked in where it's used. We use this method for building Node binary releases.
+>
+> \-- <cite>[**@rvagg**](https://github.com/rvagg) ([prebuild/docker-images#8](https://github.com/prebuild/docker-images/pull/8))</cite>
+
+Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the libc flavor, to set them apart from musl prebuilds, e.g. `linux-x64/node.glibc.node`.
+
+### [`alpine`](https://github.com/orgs/prebuild/packages/container/package/alpine)
+
+Compile in Alpine, which uses musl instead of glibc and therefore can't run regular linux prebuilds. Worse, it sometimes does successfully _load_ such a  prebuild during `npm install` - which prevents a compilation fallback from kicking in - and then segfaults at runtime. You can fix this situation in two ways: by shipping an `alpine` prebuild and/or by shipping a `centos7-devtoolset7` prebuild, because the latter will be skipped in Alpine thanks to the `glibc` tag.
+
+Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the libc flavor, to set them apart from glibc prebuilds, e.g. `linux-x64/node.musl.node`.
+
+### [`linux-armv6`](https://github.com/orgs/prebuild/packages/container/package/linux-armv6)
+
+Cross-compile for Linux ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (6).
+
+### [`linux-armv7`](https://github.com/orgs/prebuild/packages/container/package/linux-armv7)
+
+Cross-compile for Linux ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (7).
+
+### [`linux-arm64`](https://github.com/orgs/prebuild/packages/container/package/linux-arm64)
+
+Cross-compile for Linux ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (8).
+
+### [`android-armv7`](https://github.com/orgs/prebuild/packages/container/package/android-armv7)
+
+Cross-compile for Android ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (7).
+
+### [`android-arm64`](https://github.com/orgs/prebuild/packages/container/package/android-arm64)
+
+Cross-compile for Android ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (8).
+
+## Old images
+
+Images were previously hosted on Docker Hub. These are no longer updated:
+
+- [`centos7-devtoolset7`](https://hub.docker.com/r/prebuild/centos7-devtoolset7)
+- [`alpine`](https://hub.docker.com/r/prebuild/alpine)
+- [`linux-armv6`](https://hub.docker.com/r/prebuild/linux-armv6)
+- [`linux-armv7`](https://hub.docker.com/r/prebuild/linux-armv7)
+- [`linux-arm64`](https://hub.docker.com/r/prebuild/linux-arm64)
+- [`android-armv7`](https://hub.docker.com/r/prebuild/android-armv7)
+- [`android-arm64`](https://hub.docker.com/r/prebuild/android-arm64)
 
 ## License
 
-Licensed under the GPLv3, see [LICENSE](./LICENSE) file for details.
-
-Copyright © 2019 `prebuild` contributors.
+[GPLv3](LICENSE) © 2019 `prebuild` contributors.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Docker images for cross compiling prebuilt binaries for Node.js. Used by [`prebuildify-cross`](https://github.com/prebuild/prebuildify-cross).**
 
+[![Release](https://img.shields.io/github/v/release/prebuild/docker-images)](https://github.com/prebuild/docker-images/releases/latest)
 [![Release](https://github.com/prebuild/docker-images/actions/workflows/release.yml/badge.svg)](https://github.com/prebuild/docker-images/actions/workflows/release.yml)
+[![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
 
 ## About
 
@@ -13,7 +15,7 @@ All images include `node`, `npm`, `npx` and a build toolchain suitable for `node
 v12.16.0
 ```
 
-Images are tagged with a major version number as well as `latest`. For example, use the following to pin to version 1:
+Images are tagged with a major, minor and full version as well as `latest`. For example, use the following to pin to major version 1:
 
 ```dockerfile
 FROM ghcr.io/prebuild/alpine:1
@@ -73,4 +75,4 @@ Images were previously hosted on Docker Hub. These are no longer updated:
 
 ## License
 
-[GPLv3](LICENSE) © 2019 `prebuild` contributors.
+[GPL-3.0-only](LICENSE) © 2019 `prebuild` contributors.

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/alpine .
-
-push:
-	docker push prebuild/alpine

--- a/android-arm64/Makefile
+++ b/android-arm64/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/android-arm64 .
-
-push:
-	docker push prebuild/android-arm64

--- a/android-armv7/Makefile
+++ b/android-armv7/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/android-armv7 .
-
-push:
-	docker push prebuild/android-armv7

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/devtoolset-7-toolchain-centos7
+FROM centos/devtoolset-7-toolchain-centos7:7
 
 USER 0
 

--- a/centos7-devtoolset7/Makefile
+++ b/centos7-devtoolset7/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/centos7-devtoolset7 .
-
-push:
-	docker push prebuild/centos7-devtoolset7

--- a/linux-arm64/Makefile
+++ b/linux-arm64/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/linux-arm64 .
-
-push:
-	docker push prebuild/linux-arm64

--- a/linux-armv6/Makefile
+++ b/linux-armv6/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/linux-armv6 .
-
-push:
-	docker push prebuild/linux-armv6

--- a/linux-armv7/Makefile
+++ b/linux-armv7/Makefile
@@ -1,5 +1,0 @@
-build:
-	docker build -t prebuild/linux-armv7 .
-
-push:
-	docker push prebuild/linux-armv7


### PR DESCRIPTION
Instead of Docker Hub Autobuild (#16), use a GitHub Actions workflow that is triggered by a git tag and publishes images to the GitHub Container Registry. Making image changes more explicit, though further work will be required to fully prevent accidental breaking changes like #17.

In this new workflow, each image gets version tags sourced from the git tag, starting at version 1.0.0. E.g. one can pull `prebuild/alpine:1`, `prebuild/alpine:1.0`, `prebuild/alpine:1.0.0` or (same as before) `prebuild/alpine:latest`. This will allow us to make breaking changes like #15 and #10.