### PR TITLE
Addition of Python 3

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 RUN addgroup -g 2000 travis && \
   adduser -u 2000 -G travis -s /bin/sh -D travis && \
-  apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python python3 git
+  apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3 git
 
 USER node
 WORKDIR /app

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 
 RUN addgroup -g 2000 travis && \
   adduser -u 2000 -G travis -s /bin/sh -D travis && \
-  apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python git
+  apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python python3 git
 
 USER node
 WORKDIR /app

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -6,7 +6,7 @@ RUN groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
   groupadd -g 2000 travis && useradd -g 2000 -u 2000 -m travis && \
   curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash - && \
   yum install -y make nodejs && \
-  npm -v
+  npm -v && \
   yum install -y python3 && \
   python3 --version
 

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -7,6 +7,8 @@ RUN groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
   curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash - && \
   yum install -y make nodejs && \
   npm -v
+  yum install -y python3 && \
+  python3 --version
 
 USER node
 


### PR DESCRIPTION
Inclusion of Python 3 for Centos and Alpine

FOR REVIEW / TESTING

I've tried to make as small a change as possible, and added Python 3 without removing Python 2, to avoid introducing a breaking change.  I don't think the other images require the same updates since they are based upon dockcross images.
