### PR TITLE
Add linux-arm64-lts and linux-arm64-musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           - linux-armv6
           - linux-armv7
           - linux-arm64
+          - linux-arm64-lts
+          - linux-arm64-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           - linux-armv6
           - linux-armv7
           - linux-arm64
+          - linux-arm64-lts
+          - linux-arm64-musl
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Cross-compile for Linux ARM. This image thinly wraps a [`dockcross`](https://git
 
 Cross-compile for Linux ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (8).
 
+### [`linux-arm64-lts`](https://github.com/orgs/prebuild/packages/container/package/linux-arm64-lts)
+
+Cross-compile for Linux ARM. This image uses an old version of glibc (glibc 2.27) for compatibility. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (8).
+
+### [`linux-arm64-musl`](https://github.com/orgs/prebuild/packages/container/package/linux-arm64-musl)
+
+Cross-compile for Linux ARM. This image uses musl instead of glibc for Alpine linux. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (8).
+
 ### [`android-armv7`](https://github.com/orgs/prebuild/packages/container/package/android-armv7)
 
 Cross-compile for Android ARM. This image thinly wraps a [`dockcross`](https://github.com/dockcross/dockcross) image. Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the armv version (7).

--- a/linux-arm64-lts/Dockerfile
+++ b/linux-arm64-lts/Dockerfile
@@ -1,0 +1,43 @@
+FROM dockcross/linux-arm64-lts
+
+RUN groupadd --gid 1000 node && useradd --uid 1000 --gid node --shell /bin/bash --create-home node && \
+  groupadd --gid 2000 travis && useradd --uid 2000 --gid travis --shell /bin/bash --create-home travis && \
+  apt-get -y update && \
+  apt-get -y --no-install-recommends install git curl gnupg apt-transport-https && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
+  curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+  apt-get -y install nodejs && \
+  npm -v && \
+  test -f ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip && \
+  rm -rf /var/lib/apt/lists/*
+
+USER node
+ENV HOME /home/node
+
+ENV PREBUILD_STRIP_BIN ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip
+ENV PREBUILD_ARCH arm64
+ENV PREBUILD_ARMV 8
+ENV PREBUILD_PLATFORM linux
+
+# TODO: These are for backwards compat. Remove once we have versioning.
+ENV STRIP ${PREBUILD_STRIP_BIN}
+ENV ARCH ${PREBUILD_ARCH}
+ENV ARM_VERSION ${PREBUILD_ARMV}
+ENV TARGET_PLATFORM ${PREBUILD_PLATFORM}
+
+# Disable npm update check
+ENV NO_UPDATE_NOTIFIER true
+ENV npm_config_update_notifier false
+
+# Set inherited dockcross labels to empty values.
+# Labels can't be deleted (https://github.com/moby/moby/issues/3465)
+LABEL org.label-schema.build-date=
+LABEL org.label-schema.name=
+LABEL org.label-schema.schema-version=
+LABEL org.label-schema.vcs-ref=
+LABEL org.label-schema.vcs-url=
+LABEL org.label-schema.version=
+
+WORKDIR /app

--- a/linux-arm64-musl/Dockerfile
+++ b/linux-arm64-musl/Dockerfile
@@ -1,0 +1,43 @@
+FROM dockcross/linux-arm64-musl
+
+RUN groupadd --gid 1000 node && useradd --uid 1000 --gid node --shell /bin/bash --create-home node && \
+  groupadd --gid 2000 travis && useradd --uid 2000 --gid travis --shell /bin/bash --create-home travis && \
+  apt-get -y update && \
+  apt-get -y --no-install-recommends install git curl gnupg apt-transport-https && \
+  echo Package: nodejs >> /etc/apt/preferences.d/preferences && \
+  echo Pin: origin deb.nodesource.com >> /etc/apt/preferences.d/preferences && \
+  echo Pin-Priority: 1000 >> /etc/apt/preferences.d/preferences && \
+  curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+  apt-get -y install nodejs && \
+  npm -v && \
+  test -f ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip && \
+  rm -rf /var/lib/apt/lists/*
+
+USER node
+ENV HOME /home/node
+
+ENV PREBUILD_STRIP_BIN ${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip
+ENV PREBUILD_ARCH arm64
+ENV PREBUILD_ARMV 8
+ENV PREBUILD_PLATFORM linux
+
+# TODO: These are for backwards compat. Remove once we have versioning.
+ENV STRIP ${PREBUILD_STRIP_BIN}
+ENV ARCH ${PREBUILD_ARCH}
+ENV ARM_VERSION ${PREBUILD_ARMV}
+ENV TARGET_PLATFORM ${PREBUILD_PLATFORM}
+
+# Disable npm update check
+ENV NO_UPDATE_NOTIFIER true
+ENV npm_config_update_notifier false
+
+# Set inherited dockcross labels to empty values.
+# Labels can't be deleted (https://github.com/moby/moby/issues/3465)
+LABEL org.label-schema.build-date=
+LABEL org.label-schema.name=
+LABEL org.label-schema.schema-version=
+LABEL org.label-schema.vcs-ref=
+LABEL org.label-schema.vcs-url=
+LABEL org.label-schema.version=
+
+WORKDIR /app


### PR DESCRIPTION
## Description
This PR add two docker images:
- `linux-arm64-lts`: arm64 image with glibc 2.27
- `linux-arm64-musl`: arm64 image with musl as libc

## Context
We are running Node.js on an arm server. But when prebuilding native extension, we encounter the following issue:
- linux-arm64 image has Glibc 2.34, which is higher than the official image on the docker hub (`node:lts-bullseye`), which is 2.31
- no alpine (musl) base image for arm64
