### PR TITLE
Fix python in urlgrabber-ext-down

### DIFF
--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -7,6 +7,7 @@ RUN groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
   curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash - && \
   yum install -y make nodejs python3 && \
   sed -i 's/#!\/usr\/bin\/python/#!\/usr\/bin\/python2/' /usr/bin/yum && \
+  sed -i 's/#! \/usr\/bin\/python/#! \/usr\/bin\/python2/' /usr/libexec/urlgrabber-ext-down && \
   ln -sf python3 /usr/bin/python && \
   yum clean all && \
   rm -rf /var/cache/yum && \


### PR DESCRIPTION
Replace python version in `/usr/libexec/urlgrabber-ext-down` to fix yum on `centos7-devtoolset7`

Fixes https://github.com/prebuild/docker-images/issues/28