### PR TITLE
Add `almalinux-devtoolset11` image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
     directory: /
     schedule:
       interval: monthly
-  # Other base images are unversioned
-  - package-ecosystem: docker
-    directory: /centos7-devtoolset7
-    schedule:
-      interval: monthly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           - alpine
           - android-armv7
           - android-arm64
-          - centos7-devtoolset7
+          - almalinux-devtoolset11
           - linux-armv6
           - linux-armv7
           - linux-armv7l-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - alpine
           - android-armv7
           - android-arm64
-          - centos7-devtoolset7
+          - almalinux-devtoolset11
           - linux-armv6
           - linux-armv7
           - linux-armv7l-musl

--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ Images that are based on [`dockcross`](https://github.com/dockcross/dockcross) (
 
 ## Images
 
+### [`almalinux-devtoolset11`](https://github.com/orgs/prebuild/packages/container/package/almalinux-devtoolset11)
+
+Compile in AlmaLinux 8 with Red Hat Developer Toolset 11. This increases compatibility with Linux flavors because prebuilds will be compiled with GCC 11 but at runtime they will only require glibc 2.28. For comparison, compiling on Ubuntu 24.04 would require glibc 2.35.
+
+Node.js binaries are built with a similar approach but the Node.js project uses RHEL 8 (which requires a Red Hat subscription) instead of AlmaLinux.
+
+Preconfigures `prebuildify` to [tag](https://github.com/prebuild/prebuildify#options) prebuilds with the libc flavor, to set them apart from musl prebuilds, e.g. `linux-x64/node.glibc.node`.
+
 ### [`centos7-devtoolset7`](https://github.com/orgs/prebuild/packages/container/package/centos7-devtoolset7)
 
-Compile in CentOS 7, as a better alternative to (commonly) Ubuntu 16.04 on Travis or GitHub Actions. Makes prebuilds compatible with Debian 8, Ubuntu 14.04, RHEL 7, CentOS 7 and other Linux flavors with an old glibc.
+_This image is not updated anymore and does not support Node.js 18 and C++ 20. Instead use `almalinux-devtoolset11`._
 
-> The neat thing about this is that you get to compile with gcc 7 but glibc 2.17, so binaries are compatible for \[among others] Ubuntu 14.04 and Debian 8.
->
-> The RHEL folks put in a ton of work to make the devtoolsets work on their older base systems (libc mainly), which involves shipping a delta library that contains the new stuff that can be statically linked in where it's used. We use this method for building Node binary releases.
+Compile in CentOS 7 with Red Hat Developer Toolset 7. This increases compatibility with Linux flavors because prebuilds will be compiled with GCC 7 but at runtime they will only require glibc 2.17. Makes prebuilds compatible with Debian 8, Ubuntu 14.04, RHEL 7, CentOS 7 and other Linux flavors with an old glibc.
+
+> The RHEL folks put in a ton of work to make the devtoolsets work on their older base systems (libc mainly), which involves shipping a delta library that contains the new stuff that can be statically linked in where it's used.
 >
 > \-- <cite>[**@rvagg**](https://github.com/rvagg) ([prebuild/docker-images#8](https://github.com/prebuild/docker-images/pull/8))</cite>
 

--- a/almalinux-devtoolset11/Dockerfile
+++ b/almalinux-devtoolset11/Dockerfile
@@ -1,0 +1,29 @@
+FROM almalinux:8-minimal
+
+USER 0
+
+# Need shadow-utils for groupadd and useradd
+# TODO: "source scl_source enable gcc-toolset-11" only applies to current session
+RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
+  microdnf install -y shadow-utils make nodejs python3 gcc-toolset-11 && \
+  source scl_source enable gcc-toolset-11 && \
+  ln -s python3 /usr/bin/python && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
+  groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
+  groupadd -g 2000 travis && useradd -g 2000 -u 2000 -m travis && \
+  npm -v && \
+  python --version
+
+USER node
+ENV HOME /home/node
+
+# Testing
+RUN gcc -dumpversion
+RUN echo -e '#include <stdio.h>\n#include <gnu/libc-version.h>\nint main(){printf("%u.%u\\n",__GLIBC__,__GLIBC_MINOR__);}' | gcc -xc++ -o dummy - && ./dummy
+
+# Disable npm update check
+ENV NO_UPDATE_NOTIFIER true
+ENV npm_config_update_notifier false
+
+WORKDIR /app

--- a/almalinux-devtoolset11/Dockerfile
+++ b/almalinux-devtoolset11/Dockerfile
@@ -3,10 +3,8 @@ FROM almalinux:8-minimal
 USER 0
 
 # Need shadow-utils for groupadd and useradd
-# TODO: "source scl_source enable gcc-toolset-11" only applies to current session
 RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
   microdnf install -y shadow-utils make nodejs python3 gcc-toolset-11 && \
-  source scl_source enable gcc-toolset-11 && \
   ln -s python3 /usr/bin/python && \
   microdnf clean all && \
   rm -rf /var/cache/yum && \
@@ -16,14 +14,13 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
   python --version
 
 USER node
-ENV HOME /home/node
+ENV HOME=/home/node
 
-# Testing
-RUN gcc -dumpversion
-RUN echo -e '#include <stdio.h>\n#include <gnu/libc-version.h>\nint main(){printf("%u.%u\\n",__GLIBC__,__GLIBC_MINOR__);}' | gcc -xc++ -o dummy - && ./dummy
+# Add gcc to PATH as alternative to "source scl_source enable gcc-toolset-11"
+ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
 
 # Disable npm update check
-ENV NO_UPDATE_NOTIFIER true
-ENV npm_config_update_notifier false
+ENV NO_UPDATE_NOTIFIER=true
+ENV npm_config_update_notifier=false
 
 WORKDIR /app

--- a/almalinux-devtoolset11/Dockerfile
+++ b/almalinux-devtoolset11/Dockerfile
@@ -4,8 +4,8 @@ USER 0
 
 # Need shadow-utils for groupadd and useradd
 RUN curl -fsSL https://rpm.nodesource.com/setup_18.x | bash - && \
-  microdnf install -y shadow-utils make nodejs python3 gcc-toolset-11 && \
-  ln -s python3 /usr/bin/python && \
+  microdnf install -y shadow-utils make nodejs python3.11 gcc-toolset-11 && \
+  ln -s python3.11 /usr/bin/python && \
   microdnf clean all && \
   rm -rf /var/cache/yum && \
   groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \

--- a/centos7-devtoolset7/Dockerfile
+++ b/centos7-devtoolset7/Dockerfile
@@ -5,6 +5,8 @@ USER 0
 # Using Node.js 16 here instead of LTS because >= 18 doesn't support CentOS 7. See:
 # - https://nodejs.org/en/blog/announcements/v18-release-announce/#toolchain-and-compiler-upgrades
 # - https://github.com/prebuild/prebuildify-cross/issues/13
+#
+# Can no longer be built: mirrorlist.centos.org is offline.
 RUN groupadd -g 1000 node && useradd -g 1000 -u 1000 -m node && \
   groupadd -g 2000 travis && useradd -g 2000 -u 2000 -m travis && \
   curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \


### PR DESCRIPTION
As alternative to `centos7-devtoolset7` which:

- No longer builds (because `mirrorlist.centos.org` is offline)
- Doesn't support Node.js >= 18
- Doesn't support C++ 20
- Ships an EOL python version (3.6.8) which doesn't work with `node-gyp` 10

Ref: https://github.com/prebuild/prebuildify-cross/issues/13
Ref: https://github.com/Level/classic-level/pull/103#issuecomment-2425151110